### PR TITLE
chore: implement code coverage check (ENG-50810)

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -25,3 +25,11 @@ jobs:
               run: |
                   npm ci
                   npm run test-ci
+
+            - name: Code coverage threshold not met
+              run: |
+                  echo "Looks like the new changes are not meeting the code coverage threshold."
+                  echo "View the code coverage details in the previous step."
+                  echo "For a more detailed view of the reports run npm run test-ci locally."
+                  echo "This will produce a detailed HTMl report, which will be present at coverage/src/index.html."
+              if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist
 /.idea
 /storybook-static
+/coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@ node_modules/
 dist/
 storybook-static/
 assets/
+coverage/
 # Files
 .prettierrc
 package.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
     coveragePathIgnorePatterns: ['/dist/', '/node_modules/', '/jest-helpers/'],
     coverageThreshold: {
         global: {
-            branches: 40,
+            branches: 50,
             functions: 29,
             lines: 46,
             statements: 45,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+    clearMocks: true,
+    moduleNameMapper: {
+        '^react$': '@bluecateng/jest-helpers/mock-react',
+        '^react-dom$': '@bluecateng/jest-helpers/mock-react',
+        '^react/jsx-runtime$': '@bluecateng/jest-helpers/mock-react',
+        '\\.(png|jpg|gif|svg|ttf|woff2)$':
+            '@bluecateng/jest-helpers/file-mapper',
+        '\\.(less)$': '@bluecateng/jest-helpers/style-mapper',
+    },
+    setupFiles: ['<rootDir>/jest-helpers/setup-globals'],
+    setupFilesAfterEnv: ['@bluecateng/jest-helpers/setup-enzyme'],
+    transform: {
+        '\\.[jt]sx?$': 'babel-jest',
+        '\\.po$': '@bluecateng/l10n-jest',
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(lodash-es|@bluecat|@bluecateng)/)',
+    ],
+    collectCoverage: true,
+    coverageReporters: ['text', 'html'],
+    coveragePathIgnorePatterns: ['/dist/', '/node_modules/', '/jest-helpers/'],
+    coverageThreshold: {
+        global: {
+            branches: 40,
+            functions: 29,
+            lines: 46,
+            statements: 45,
+        },
+    },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
     coveragePathIgnorePatterns: ['/dist/', '/node_modules/', '/jest-helpers/'],
     coverageThreshold: {
         global: {
-            branches: 50,
+            branches: 40,
             functions: 29,
             lines: 46,
             statements: 45,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "copy-resources": "node scripts/copy-resources",
         "prepare": "husky install .husky",
         "test": "jest",
-        "test-ci": "jest --ci --silent",
+        "test-ci": "jest --ci",
         "lint-styles": "stylelint src/**/*.less",
         "prettier-check": "prettier --check --config ./.prettierrc . --ignore-path ./.prettierignore",
         "eslint-ci": "eslint .",
@@ -119,29 +119,6 @@
             "@bluecateng/stylelint-config"
         ],
         "customSyntax": "postcss-less"
-    },
-    "jest": {
-        "clearMocks": true,
-        "moduleNameMapper": {
-            "^react$": "@bluecateng/jest-helpers/mock-react",
-            "^react-dom$": "@bluecateng/jest-helpers/mock-react",
-            "^react/jsx-runtime$": "@bluecateng/jest-helpers/mock-react",
-            "\\.(png|jpg|gif|svg|ttf|woff2)$": "@bluecateng/jest-helpers/file-mapper",
-            "\\.(less)$": "@bluecateng/jest-helpers/style-mapper"
-        },
-        "setupFiles": [
-            "<rootDir>/jest-helpers/setup-globals"
-        ],
-        "setupFilesAfterEnv": [
-            "@bluecateng/jest-helpers/setup-enzyme"
-        ],
-        "transform": {
-            "\\.[jt]sx?$": "babel-jest",
-            "\\.po$": "@bluecateng/l10n-jest"
-        },
-        "transformIgnorePatterns": [
-            "node_modules/(?!(lodash-es|@bluecat|@bluecateng)/)"
-        ]
     },
     "msw": {
         "workerDirectory": ".storybook/mswpublic"


### PR DESCRIPTION
- Implement code coverage check with JEST
- The JEST GitHub workflow will now fail and prevent pull request from being merged if the code coverage threshold is not met.
- Moved the JEST configuration from `package.json` to a specific JEST configuration file (`jest.config.js`).
- In the GitHub job you can see the output of code coverage reports, includes which lines we are not testing with the threshold percentage for each file.