### PR TITLE
chore: add Storybook building and publishing to GitHub pages (ENG-50804)

### DIFF
--- a/.github/workflows/storybook-publish.yaml
+++ b/.github/workflows/storybook-publish.yaml
@@ -1,5 +1,5 @@
-name: Build and deploy storybook
-run-name: ${{ github.actor }} is running build and deploy storybook
+name: Build and deploy Storybook
+run-name: ${{ github.actor }} is running build and deploy Storybook
 on:
     push:
         branches: ['main']
@@ -7,14 +7,14 @@ on:
 permissions: read-all
 jobs:
     build:
-        name: Running build storybook
+        name: Running build Storybook
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout code
               uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # tag=v4.1.0
 
-            - name: Build storybook
+            - name: Build Storybook
               run: |
                   npm ci
                   npm run storybook-build-static
@@ -27,7 +27,7 @@ jobs:
     deploy:
         needs: build
         runs-on: ubuntu-latest
-        name: Running deploy storybook
+        name: Running deploy Storybook
 
         permissions:
             pages: write

--- a/.github/workflows/storybook-publish.yaml
+++ b/.github/workflows/storybook-publish.yaml
@@ -1,0 +1,43 @@
+name: Build and deploy storybook
+run-name: ${{ github.actor }} is running build and deploy storybook
+on:
+    push:
+        branches: ['main']
+
+permissions: read-all
+jobs:
+    build:
+        name: Running build storybook
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # tag=v4.1.0
+
+            - name: Build storybook
+              run: |
+                  npm ci
+                  npm run storybook-build-static
+
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # tag=v2.0.0
+              with:
+                  path: storybook-static
+
+    deploy:
+        needs: build
+        runs-on: ubuntu-latest
+        name: Running deploy storybook
+
+        permissions:
+            pages: write
+            id-token: write
+
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@9dbe3824824f8a1377b8e298bafde1a50ede43e5 # tag=v2.0.4


### PR DESCRIPTION
- Add a new Github workflow that runs when a push is made to the main branch.
- The workflow builds the storybook static files.
- The workflow later used this files and publishes them to the github pages.