### PR TITLE
chore: build the package when installing from github URL (ENG-55132)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
         '__tests__/**',
         '__mocks__/**',
         'jest-helpers/setup-globals.js',
+        'dist/**',
     ],
     'rules': {
         // enable additional rules

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "publish-dev-package": "npm publish --registry ${NPM_REGISTRY_REPLACE_THIS_VALUE} --tag dev",
         "build": "rm -rf dist && babel src -d dist --env-name production && npm run copy-resources dist",
         "copy-resources": "node scripts/copy-resources",
-        "prepare": "husky install .husky",
+        "prepare": "husky install .husky ; npm run build",
         "test": "jest",
         "test-ci": "jest --ci",
         "lint-styles": "stylelint src/**/*.less",


### PR DESCRIPTION
This allows the developers to install the package like this 
`npm install github:bluecatengineering/limani#main`