### PR TITLE
feat: add View Logs to System Header Menu (ENG-55440)

### DIFF
--- a/__tests__/components/HeaderSystemMenu.test.js
+++ b/__tests__/components/HeaderSystemMenu.test.js
@@ -92,11 +92,7 @@ describe('HeaderSystemMenu', () => {
                 guardProps: null,
             });
             const wrapper = shallow(
-                <HeaderSystemMenu
-                    className='customSystemMenu'
-                    canDownloadLogs={true}
-                    canViewLogs={true}
-                />,
+                <HeaderSystemMenu className='customSystemMenu' />,
             );
             expect(wrapper.getElement()).toMatchSnapshot();
         });
@@ -109,11 +105,7 @@ describe('HeaderSystemMenu', () => {
             });
             setLanguage('zz').finally(() => {
                 const wrapper = shallow(
-                    <HeaderSystemMenu
-                        className='customSystemMenu'
-                        canDownloadLogs={true}
-                        canViewLogs={true}
-                    />,
+                    <HeaderSystemMenu className='customSystemMenu' />,
                 );
                 expect(wrapper.getElement()).toMatchSnapshot();
             });
@@ -132,11 +124,7 @@ describe('HeaderSystemMenu', () => {
             });
             // Render the HeaderSystemMenu element
             const wrapper = shallow(
-                <HeaderSystemMenu
-                    className='customSystemMenu'
-                    canDownloadLogs={true}
-                    canViewLogs={true}
-                />,
+                <HeaderSystemMenu className='customSystemMenu' />,
             );
 
             // Click the view logs menu option
@@ -161,11 +149,7 @@ describe('HeaderSystemMenu', () => {
             });
             // Render the HeaderSystemMenu element
             const wrapper = shallow(
-                <HeaderSystemMenu
-                    className='customSystemMenu'
-                    canDownloadLogs={true}
-                    canViewLogs={true}
-                />,
+                <HeaderSystemMenu className='customSystemMenu' />,
             );
             // Click the download logs button
             wrapper.find('#systemMenu-dl_logs').simulate('click');

--- a/__tests__/components/HeaderSystemMenu.test.js
+++ b/__tests__/components/HeaderSystemMenu.test.js
@@ -30,13 +30,21 @@ jest.mock('../../src/hooks/usePlatformData', () =>
     jest
         .fn()
         .mockReturnValueOnce({
-            data: { user: { permissions: { download_logs: false } } },
+            data: {
+                user: {
+                    permissions: { download_logs: false, view_logs: false },
+                },
+            },
         })
         .mockReturnValueOnce({
-            data: { user: { permissions: { download_logs: true } } },
+            data: {
+                user: { permissions: { download_logs: true, view_logs: true } },
+            },
         })
         .mockReturnValueOnce({
-            data: { user: { permissions: { download_logs: true } } },
+            data: {
+                user: { permissions: { download_logs: true, view_logs: true } },
+            },
         }),
 );
 
@@ -44,7 +52,10 @@ describe('HeaderSystemMenu', () => {
     describe('Rendering', () => {
         it('Render HeaderSystemMenu component with default props', () => {
             const wrapper = shallow(
-                <HeaderSystemMenu canDownloadLogs={false} />,
+                <HeaderSystemMenu
+                    canDownloadLogs={false}
+                    canViewLogs={false}
+                />,
             );
             expect(wrapper.getElement()).toMatchSnapshot();
         });
@@ -54,6 +65,7 @@ describe('HeaderSystemMenu', () => {
                 <HeaderSystemMenu
                     className='customSystemMenu'
                     canDownloadLogs={true}
+                    canViewLogs={true}
                 />,
             );
             expect(wrapper.getElement()).toMatchSnapshot();
@@ -64,6 +76,7 @@ describe('HeaderSystemMenu', () => {
                     <HeaderSystemMenu
                         className='customSystemMenu'
                         canDownloadLogs={true}
+                        canViewLogs={true}
                     />,
                 );
                 expect(wrapper.getElement()).toMatchSnapshot();

--- a/__tests__/components/HeaderSystemMenu.test.js
+++ b/__tests__/components/HeaderSystemMenu.test.js
@@ -45,6 +45,16 @@ jest.mock('../../src/hooks/usePlatformData', () =>
             data: {
                 user: { permissions: { download_logs: true, view_logs: true } },
             },
+        })
+        .mockReturnValueOnce({
+            data: {
+                user: { permissions: { download_logs: true, view_logs: true } },
+            },
+        })
+        .mockReturnValueOnce({
+            data: {
+                user: { permissions: { download_logs: true, view_logs: true } },
+            },
         }),
 );
 
@@ -80,6 +90,78 @@ describe('HeaderSystemMenu', () => {
                     />,
                 );
                 expect(wrapper.getElement()).toMatchSnapshot();
+            });
+        });
+        describe('Menu items', () => {
+            it('download logs', () => {
+                const mockWindowOpen = jest.fn();
+                global.window.open = mockWindowOpen;
+
+                // Mock window url
+                delete global.window.location;
+                global.window.location = { href: '' };
+
+                const wrapper = shallow(
+                    <HeaderSystemMenu
+                        canDownloadLogs={true}
+                        canViewLogs={true}
+                    />,
+                );
+
+                // Click system menu button
+                wrapper.find('#systemMenuButton').simulate('click');
+
+                setTimeout(() => {
+                    // Wait until system menu is clickable
+                    expect(wrapper.find('#systemMenu-dl_logs').exists()).toBe(
+                        true,
+                    );
+                }, 500);
+
+                // Click download logs
+                wrapper.find('#systemMenu-dl_logs').simulate('click'); //cant click this ?
+
+                setTimeout(() => {
+                    // Assert new window was opened
+                    expect(mockWindowOpen).toHaveBeenCalledTimes(1);
+                    // Assert new window was redirected to download logs url
+                    expect(mockWindowOpen).toHaveBeenCalledWith(
+                        '/admin/logs/download',
+                        '_blank',
+                    );
+                }, 500);
+            });
+            it('view logs', () => {
+                // Mock window url
+                delete global.window.location;
+                global.window.location = { href: '' };
+
+                const wrapper = shallow(
+                    <HeaderSystemMenu
+                        canDownloadLogs={true}
+                        canViewLogs={true}
+                    />,
+                );
+
+                // Click system menu
+                wrapper.find('#systemMenuButton').simulate('click');
+
+                setTimeout(() => {
+                    // Wait until download logs exists
+                    expect(wrapper.find('#systemMenu-vw_logs').exists()).toBe(
+                        true,
+                    );
+                }, 500);
+
+                // Click view logs
+                wrapper.find('#systemMenu-vw_logs').simulate('click'); // Cant click this
+
+                setTimeout(() => {
+                    // Assert window was redirected to view logs
+                    expect(global.window.location.href).toBe(
+                        '/admin/view_logs',
+                    );
+                }, 500);
             });
         });
     });

--- a/__tests__/components/HeaderSystemMenu.test.js
+++ b/__tests__/components/HeaderSystemMenu.test.js
@@ -56,11 +56,6 @@ jest.mock('../../src/hooks/usePlatformData', () =>
             data: {
                 user: { permissions: { download_logs: true, view_logs: true } },
             },
-        })
-        .mockReturnValueOnce({
-            data: {
-                user: { permissions: { download_logs: true, view_logs: true } },
-            },
         }),
 );
 
@@ -75,12 +70,7 @@ describe('HeaderSystemMenu', () => {
                 menuProps: null,
                 guardProps: null,
             });
-            const wrapper = shallow(
-                <HeaderSystemMenu
-                    canDownloadLogs={false}
-                    canViewLogs={false}
-                />,
-            );
+            const wrapper = shallow(<HeaderSystemMenu />);
             expect(wrapper.getElement()).toMatchSnapshot();
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bluecat/limani",
-    "version": "1.1.6-dev",
+    "version": "1.1.7-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bluecat/limani",
-            "version": "1.1.6-dev",
+            "version": "1.1.7-dev",
             "license": "MIT",
             "dependencies": {
                 "@fortawesome/free-regular-svg-icons": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bluecat/limani",
-    "version": "1.1.6-dev",
+    "version": "1.1.7-dev",
     "description": "Gateway shared components",
     "usage": "dev",
     "scripts": {

--- a/src/header/HeaderSystemMenu.js
+++ b/src/header/HeaderSystemMenu.js
@@ -37,9 +37,9 @@ import './HeaderSystemMenu.less';
  * HeaderSystemMenu component is a button when clicked this button reveals the
  * links to System menu options. <br>
  * With user access permission, two options for retrieving logs are available.
- * "Download logs" retrieves all logs as a single file, and "View logs" allows
- * the 1000 lines of the log to be viewed in the UI, where they can be
- * searched and filtered interactively. <br/>
+ * "Download logs" retrieves all logs as a single file, and "View logs" shows
+ * the last 1000 lines of relevant Gateway logs, providing searching and
+ * filtering options. <br/>
  * This component is intended to be nested inside the PlatformDataContext as
  * it will require access to PlatformData. <br>
  * The component should always be wrapped inside parent element that

--- a/src/header/HeaderSystemMenu.js
+++ b/src/header/HeaderSystemMenu.js
@@ -48,8 +48,10 @@ import './HeaderSystemMenu.less';
 const HeaderSystemMenu = ({ className }) => {
     const { data } = usePlatformData();
     const canDownloadLogs = data?.user?.permissions.download_logs;
+    const canViewLogs = data?.user?.permissions.view_logs;
     const downloadLogs = () =>
         window.open('/admin/logs/download', '_blank').focus();
+    const viewLogs = () => window.open('admin/logs/view', '_blank').focus();
 
     const { expanded, buttonProps, menuProps, guardProps } = useMenuHandler();
 
@@ -57,7 +59,7 @@ const HeaderSystemMenu = ({ className }) => {
 
     return (
         <>
-            {canDownloadLogs && (
+            {(canDownloadLogs || canViewLogs) && (
                 <div className={className}>
                     <button
                         id='systemMenuButton'
@@ -81,11 +83,20 @@ const HeaderSystemMenu = ({ className }) => {
                             aria-label={`System Menu`}>
                             <div tabIndex={0} {...guardProps} />
                             <Menu {...menuProps}>
-                                <MenuItem
-                                    id='systemMenu-dl_logs'
-                                    onClick={
-                                        downloadLogs
-                                    }>{t`Download logs`}</MenuItem>
+                                {canDownloadLogs && (
+                                    <MenuItem
+                                        id='systemMenu-dl_logs'
+                                        onClick={
+                                            downloadLogs
+                                        }>{t`Download logs`}</MenuItem>
+                                )}
+                                {canViewLogs && (
+                                    <MenuItem
+                                        id='systemMenu-vw_logs'
+                                        onClick={
+                                            viewLogs
+                                        }>{t`View logs`}</MenuItem>
+                                )}
                             </Menu>
                             <div tabIndex={0} {...guardProps} />
                         </Layer>

--- a/src/header/HeaderSystemMenu.js
+++ b/src/header/HeaderSystemMenu.js
@@ -51,7 +51,7 @@ const HeaderSystemMenu = ({ className }) => {
     const canViewLogs = data?.user?.permissions.view_logs;
     const downloadLogs = () =>
         window.open('/admin/logs/download', '_blank').focus();
-    const viewLogs = () => window.open('/admin/view_logs', '_blank').focus();
+    const viewLogs = () => window.location.replace('/admin/view_logs');
 
     const { expanded, buttonProps, menuProps, guardProps } = useMenuHandler();
 

--- a/src/header/HeaderSystemMenu.js
+++ b/src/header/HeaderSystemMenu.js
@@ -36,8 +36,10 @@ import './HeaderSystemMenu.less';
 /**
  * HeaderSystemMenu component is a button when clicked this button reveals the
  * links to System menu options. <br>
- * With user access permission, Download logs is an available option to retrieve
- * all logs as a single file. <br>
+ * With user access permission, two options for retrieving logs are available.
+ * "Download logs" retrieves all logs as a single file, and "View logs" allows
+ * the 1000 lines of the log to be viewed in the UI, where they can be
+ * searched and filtered interactively. <br/>
  * This component is intended to be nested inside the PlatformDataContext as
  * it will require access to PlatformData. <br>
  * The component should always be wrapped inside parent element that

--- a/src/header/HeaderSystemMenu.js
+++ b/src/header/HeaderSystemMenu.js
@@ -51,7 +51,7 @@ const HeaderSystemMenu = ({ className }) => {
     const canViewLogs = data?.user?.permissions.view_logs;
     const downloadLogs = () =>
         window.open('/admin/logs/download', '_blank').focus();
-    const viewLogs = () => window.open('admin/logs/view', '_blank').focus();
+    const viewLogs = () => window.open('/admin/view_logs', '_blank').focus();
 
     const { expanded, buttonProps, menuProps, guardProps } = useMenuHandler();
 

--- a/src/l10n/en.po
+++ b/src/l10n/en.po
@@ -84,6 +84,10 @@ msgstr ""
 msgid "System"
 msgstr ""
 
+#: 4c39
+msgid "View logs"
+msgstr ""
+
 #: 825c
 msgid "Workflows"
 msgstr ""

--- a/src/l10n/zz.po
+++ b/src/l10n/zz.po
@@ -84,6 +84,10 @@ msgstr "Sââvéé"
 msgid "System"
 msgstr "Systéém"
 
+#: 4c39
+msgid "View logs"
+msgstr "Vîîééw lôôgss"
+
 #: 825c
 msgid "Workflows"
 msgstr "Wôôrkflôôws"

--- a/src/l10n/zz.po
+++ b/src/l10n/zz.po
@@ -86,7 +86,7 @@ msgstr "Systéém"
 
 #: 4c39
 msgid "View logs"
-msgstr "Vîîééw lôôgss"
+msgstr "Vîîééw lôôgs"
 
 #: 825c
 msgid "Workflows"

--- a/stories/Header.stories.js
+++ b/stories/Header.stories.js
@@ -81,6 +81,7 @@ const platformMockValue = {
             ],
             permissions: {
                 download_logs: true,
+                view_logs: true,
             },
             user_type: 'user_type',
             username: 'username',

--- a/stories/HeaderSystemMenu.stories.js
+++ b/stories/HeaderSystemMenu.stories.js
@@ -27,8 +27,10 @@ const mockValue = {
     data: {
         user: {
             permissions: {
-                // eslint-disable-next-line camelcase
+                /* eslint-disable camelcase */
                 download_logs: true,
+                view_logs: true,
+                /* eslint-enable camelcase */
             },
         },
     },

--- a/stories/SimplePage.stories.js
+++ b/stories/SimplePage.stories.js
@@ -78,6 +78,7 @@ const platformMockValue = {
         ],
         permissions: {
             download_logs: true,
+            view_logs: true,
         },
         user_type: 'user_type',
         username: 'username',


### PR DESCRIPTION
- Change condition for HeaderSystemMenu component to be displayed when a user has permission to view logs OR permission to download logs
- Added view logs option in dropdown
- Added pseudo-translation for view logs option
- Updated HeaderSystemMenu, Header, and SimplePage in storybook
- Updated tests to include view logs option
<img width="1042" alt="Screen Shot 2024-04-11 at 3 07 20 PM" src="https://github.com/bluecatengineering/limani/assets/157743396/7bde05ce-cfe4-471d-8ea6-8012eeda5efc">