### PR TITLE
style(ui): update gateway icons to match BAM UI (ENG-63942)

### DIFF
--- a/src/header/HeaderAccountMenu.js
+++ b/src/header/HeaderAccountMenu.js
@@ -21,13 +21,13 @@ SOFTWARE.
 */
 import { t } from '@bluecateng/l10n.macro';
 import { Layer, Menu, MenuItem, useMenuHandler } from '@bluecateng/pelagos';
-import UserAvatar from '@carbon/icons-react/es/UserAvatar';
-
+import User from '@carbon/icons-react/es/User';
 import PropTypes from 'prop-types';
+
 import usePlatformData from '../hooks/usePlatformData';
 import { resizeButtonMenu } from '../utils/display';
-import './HeaderAccountMenu.less';
 import AppShellIcon from './AppShellIcon';
+import './HeaderAccountMenu.less';
 
 const doLogout = () => window.open('/logout', '_self');
 
@@ -63,7 +63,7 @@ const HeaderAccountMenu = ({ className }) => {
                 aria-expanded={expanded}
                 {...buttonProps}>
                 <AppShellIcon
-                    icon={UserAvatar}
+                    icon={User}
                     tooltipText={t`Account`}
                     tooltipPlacement='bottom'
                     hideTooltip={expanded}


### PR DESCRIPTION

The user account icon should match the account icon in the BAM UI, as shown in the image below
<img width="273" height="86" alt="image" src="https://github.com/user-attachments/assets/dfcfdb44-bbd6-410c-83cb-cdc801ef398d" />

Before the update
<img width="202" height="152" alt="image" src="https://github.com/user-attachments/assets/899c205c-e4f0-49d6-b60c-5170cbcc7821" />

After the update:
<img width="183" height="122" alt="image" src="https://github.com/user-attachments/assets/f6356ae6-d9ce-4884-afe0-f3f4f4e58cb3" />
